### PR TITLE
🐛 Fix syntax error bug

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -78,7 +78,19 @@ export function provideLinter() {
         return results; // return empty array when no config found
       const config = require(configFile); // TODO: potentially a slow point here
       const text = textEditor.getText();
-      const errObjs = solium.lint(text, config);
+      let errObjs;
+      try {
+        errObjs = solium.lint(text, config);
+      } catch(e) {
+        errObjs = [{
+          column: e.location.start.column,
+          line: e.location.start.line,
+          message: e.message,
+          // node:,
+          ruleName: "syntax-error",
+          type: "error"
+        }]
+      }
       errObjs.forEach(async err => {
         let message;
         let position = atomlinter.generateRange(textEditor, err.line-1, err.column);


### PR DESCRIPTION
# Why?

The linter throws an error when a syntax error occurs. Because `solium.lint` can throw an error. 

# How to solve it?

The error was not catched. Now, the error is catched and the appropriate error messages is created from the error. It allows to reuse the same structure than for standard error messages.